### PR TITLE
Fixed jvm.options for OpenJDK11 and added demo decurity config.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,11 @@ USE_RC_SUBR=	elasticsearch
 SHEBANG_FILES=	bin/elasticsearch \
 		bin/elasticsearch-cli \
 		bin/elasticsearch-env \
-		bin/elasticsearch-plugin
+		bin/elasticsearch-keystore \
+		bin/elasticsearch-node \
+		bin/elasticsearch-plugin \
+		bin/elasticsearch-shard \
+		opendistro-tar-install.sh
 
 OPTIONS_DEFINE=	DOCS
 
@@ -36,7 +40,10 @@ CONFIG_FILES=	elasticsearch.yml log4j2.properties jvm.options
 BINS=		elasticsearch \
 		elasticsearch-cli \
 		elasticsearch-env \
-		elasticsearch-plugin
+		elasticsearch-keystore \
+		elasticsearch-node \
+		elasticsearch-plugin \
+		elasticsearch-shard
 
 PORTDOCS=	LICENSE.txt \
 		NOTICE.txt \
@@ -49,15 +56,13 @@ USERS=		${SEARCHUSER}
 GROUPS=		${SEARCHGROUP}
 ETCDIR=		${PREFIX}/etc/elasticsearch
 
-SUB_LIST=	ETCDIR=${ETCDIR} JAVA=${JAVA}
+SUB_LIST=	ETCDIR=${ETCDIR} JAVA=${JAVA} JAVA_HOME=${JAVA_HOME} INSTDIR=${PREFIX}/lib/elasticsearch
 SUB_FILES=	pkg-message
 
 post-patch:
 	${REINPLACE_CMD} -e "s|%%PREFIX%%|${PREFIX}|g" ${WRKSRC}/config/elasticsearch.yml
 	${REINPLACE_CMD} -e "s|%%PREFIX%%|${PREFIX}|g" ${WRKSRC}/bin/elasticsearch
 	${RM} ${WRKSRC}/lib/jna-*.jar
-	# ML plugin not supported on FreeBSD
-	${RM} -rf ${WRKSRC}/modules/x-pack/x-pack-ml
 
 do-install:
 	${MKDIR} ${STAGEDIR}${ETCDIR}
@@ -74,10 +79,12 @@ do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/lib/elasticsearch/modules
 	(cd ${WRKSRC}/modules && ${COPYTREE_SHARE} . ${STAGEDIR}${PREFIX}/lib/elasticsearch/modules/)
 	${MKDIR} ${STAGEDIR}${PREFIX}/lib/elasticsearch/plugins
+	(cd ${WRKSRC}/plugins && ${COPYTREE_SHARE} . ${STAGEDIR}${PREFIX}/lib/elasticsearch/plugins/)
 	${MKDIR} ${STAGEDIR}${PREFIX}/libexec/elasticsearch
 	${INSTALL} -lrs ${STAGEDIR}${ETCDIR} ${STAGEDIR}${PREFIX}/lib/elasticsearch/config
 	${LN} -s ${JAVASHAREDIR}/classes/jna.jar ${STAGEDIR}${PREFIX}/lib/elasticsearch/lib/jna.jar
 
+	${INSTALL_SCRIPT} ${WRKSRC}/opendistro-tar-install.sh ${STAGEDIR}${PREFIX}/lib/elasticsearch
 do-install-DOCS-on:
 	${MKDIR} ${STAGEDIR}${DOCSDIR}
 .for f in ${PORTDOCS}

--- a/files/elasticsearch.in
+++ b/files/elasticsearch.in
@@ -32,7 +32,7 @@ load_rc_config ${name}
 : ${elasticsearch_group=elasticsearch}
 : ${elasticsearch_config=%%PREFIX%%/etc/elasticsearch}
 : ${elasticsearch_login_class=root}
-: ${elasticsearch_java_home=%%PREFIX%%}
+: ${elasticsearch_java_home=%%JAVA_HOME%%}
 : ${elasticsearch_startup_sleep_time=5}
 
 required_files="${elasticsearch_config}/elasticsearch.yml"

--- a/files/patch-config_elasticsearch.yml
+++ b/files/patch-config_elasticsearch.yml
@@ -13,10 +13,3 @@
  #
  # ----------------------------------- Memory -----------------------------------
  #
-@@ -86,3 +88,6 @@
- # Require explicit names when deleting indices:
- #
- #action.destructive_requires_name: true
-+
-+# ml is not supported on FreeBSD
-+xpack.ml.enabled: false

--- a/files/patch-config_jvm.options
+++ b/files/patch-config_jvm.options
@@ -1,6 +1,6 @@
---- config/jvm.options.orig	2018-03-01 23:04:45 UTC
+--- config/jvm.options.orig	2019-09-06 14:38:47 UTC
 +++ config/jvm.options
-@@ -87,7 +87,7 @@
+@@ -107,13 +107,13 @@
  8:-XX:+PrintGCDateStamps
  8:-XX:+PrintTenuringDistribution
  8:-XX:+PrintGCApplicationStoppedTime
@@ -9,3 +9,10 @@
  8:-XX:+UseGCLogFileRotation
  8:-XX:NumberOfGCLogFiles=32
  8:-XX:GCLogFileSize=64m
+
+ # JDK 9+ GC logging
+-9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
++9-:-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch//gc.log:utctime,pid,tags:filecount=32,filesize=64m
+ # due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+ # time/date parsing will break in an incompatible way for some date patterns and locals
+ 9-:-Djava.locale.providers=COMPAT

--- a/files/patch-opendistro__tar__install.sh
+++ b/files/patch-opendistro__tar__install.sh
@@ -1,0 +1,8 @@
+--- opendistro-tar-install.sh.orig	2019-12-17 19:50:35 UTC
++++ opendistro-tar-install.sh
+@@ -40,4 +40,4 @@
+ echo "done plugins"
+
+ ##Start Elastic Search
+-bash $ES_HOME/bin/elasticsearch "$@"
++#bash $ES_HOME/bin/elasticsearch "$@"

--- a/files/pkg-message.in
+++ b/files/pkg-message.in
@@ -13,12 +13,17 @@ You may need to set:
 
 sysctl security.bsd.unprivileged_mlock=1
 
+After installation, you can run a script to create a demo security
+configuration for testing.
+*** WARNING: Do not use on production or public reachable systems ***
+Simply run: cd %%INSTDIR%% && ./opendistro-tar-install.sh
+
 !!! PLUGINS NOTICE !!!
 
 ElasticSearch plugins should only be installed via the elasticsearch-plugin
 included with this software. As we strive to provide a minimum semblance
 of security, the files installed by the package are owned by root:wheel.
-This is different than upstream hich expects all of the files to be
+This is different than upstream which expects all of the files to be
 owned by the user and for you to execute the elasticsearch-plugin script
 as said user.
 


### PR DESCRIPTION
While updating the port to OD 1.3.0 I added copying some more scripts, fixed a problem in the jvm.options file which prevented ES from starting with OpenJDK11 and added the opendistro-tar-install.sh script and a note about it to pkg-message.
